### PR TITLE
openshift: change default image to ubi8/nodejs-16

### DIFF
--- a/cute-name-service/package.json
+++ b/cute-name-service/package.json
@@ -7,7 +7,7 @@
     "pretest": "eslint --ignore-path ../.gitignore .",
     "test": "mocha",
     "lint:fix": "eslint . --fix",
-    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14",
+    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-16",
     "start": "node ."
   },
   "main": "./bin/www",

--- a/greeting-service/package.json
+++ b/greeting-service/package.json
@@ -8,7 +8,7 @@
     "test": "mocha",
     "lint:fix": "eslint . --fix",
     "start": "node .",
-    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14"
+    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-16"
   },
   "main": "./bin/www",
   "repository": {


### PR DESCRIPTION
Tested on crc and works as expected.

Hard to test on the sandbox due to lack of HTTPS.