### PR TITLE
fix: deprecating proxyquire dependency

### DIFF
--- a/cute-name-service/bin/www
+++ b/cute-name-service/bin/www
@@ -87,9 +87,11 @@ function onError (error) {
     case 'EACCES':
       console.error(bind + ' requires elevated privileges');
       process.exit(1);
+      break;
     case 'EADDRINUSE':
       console.error(bind + ' is already in use');
       process.exit(1);
+      break;
     default:
       throw error;
   }

--- a/cute-name-service/package-lock.json
+++ b/cute-name-service/package-lock.json
@@ -33,7 +33,6 @@
         "mocha": "^10.0.0",
         "nodeshift": "~8.7.0",
         "nyc": "~15.1.0",
-        "proxyquire": "~2.1.3",
         "supertest": "~6.2.4"
       }
     },
@@ -2885,18 +2884,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "dev": true,
@@ -3825,14 +3812,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "dev": true,
@@ -4661,11 +4640,6 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
@@ -5402,16 +5376,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
       }
     },
     "node_modules/psl": {
@@ -8710,14 +8674,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "dev": true,
@@ -9286,10 +9242,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-object": {
-      "version": "1.0.2",
-      "dev": true
-    },
     "is-plain-obj": {
       "version": "2.1.0",
       "dev": true
@@ -9852,10 +9804,6 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0"
     },
@@ -10346,15 +10294,6 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
-      }
-    },
-    "proxyquire": {
-      "version": "2.1.3",
-      "dev": true,
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
       }
     },
     "psl": {

--- a/cute-name-service/package.json
+++ b/cute-name-service/package.json
@@ -36,7 +36,6 @@
     "mocha": "^10.0.0",
     "nodeshift": "~8.7.0",
     "nyc": "~15.1.0",
-    "proxyquire": "~2.1.3",
     "supertest": "~6.2.4"
   },
   "description": "",

--- a/cute-name-service/test/cute-name-service-test.js
+++ b/cute-name-service/test/cute-name-service-test.js
@@ -7,9 +7,6 @@ const supertest = require('supertest');
 
 describe('Cute-name service', async () => {
   it('should have cute name response', async () => {
-    // this.timeout(0) disable timeout for this test
-    this.timeout(0);
-
     const response = await supertest(app)
       .get('/api/name')
       .expect('Content-Type', /html/)
@@ -20,5 +17,28 @@ describe('Cute-name service', async () => {
     assert.match(response.text.split(' ')[0], isWordRegex);
     assert.match(response.text.split(' ')[1], isWordRegex);
     assert.strictEqual(response.text.split(' ').length, 2);
+  }).timeout(5000);
+});
+
+describe('ready endpoint', () => {
+  it('should responde with OK message', async () => {
+    const response = await supertest(app)
+      .get('/ready')
+      .expect('Content-Type', /text\/plain/)
+      .expect(200);
+
+    assert.match(response.text, /OK/);
+  });
+});
+
+describe('live endpoint', () => {
+  it('should responde with OK message', async () => {
+    const response = await supertest(app)
+      .get('/ready')
+      .expect('Content-Type', /text\/plain/)
+      .expect(200);
+
+    console.log(response.text);
+    assert.match(response.text, /OK/);
   });
 });

--- a/cute-name-service/test/cute-name-service-test.js
+++ b/cute-name-service/test/cute-name-service-test.js
@@ -2,24 +2,23 @@
 'use strict';
 
 const assert = require('assert');
-const proxyquire = require('proxyquire');
+const app = require('../app');
 const supertest = require('supertest');
 
-describe('Cute-name service', () => {
-  it('should have cute name response', async function () {
+describe('Cute-name service', async () => {
+  it('should have cute name response', async () => {
+    // this.timeout(0) disable timeout for this test
     this.timeout(0);
-    const app = proxyquire('../app', {
-      'project-name-generator': () => {
-        return {
-          spaced: 'cute-name'
-        };
-      }
-    });
+
     const response = await supertest(app)
       .get('/api/name')
       .expect('Content-Type', /html/)
       .expect(200);
 
-    assert.strictEqual(response.text, 'cute-name');
+    const isWordRegex = /^[a-zA-Z]+$/;
+    assert.match('responsetextsplit', isWordRegex);
+    assert.match(response.text.split(' ')[0], isWordRegex);
+    assert.match(response.text.split(' ')[1], isWordRegex);
+    assert.strictEqual(response.text.split(' ').length, 2);
   });
 });


### PR DESCRIPTION
Deprecating proxyquire:
* proxyquire dependency does not have any update for the past three years
* proxyquire is not necessary for out tests

Added more tests for the endpoints:
* live
* ready 